### PR TITLE
Fix the bug about performance.now

### DIFF
--- a/src/WindowProperties.js
+++ b/src/WindowProperties.js
@@ -13,7 +13,8 @@ export const screen = {
 }
 export const scrollX = 0
 export const scrollY = 0
-export const performance = wx.getPerformance ? wx.getPerformance() : null;
 export const ontouchstart = null
 export const ontouchmove = null
 export const ontouchend = null
+
+export performance from './performance'

--- a/src/performance.js
+++ b/src/performance.js
@@ -1,0 +1,17 @@
+let performance
+
+if (wx.getPerformance) {
+  const { platform } = wx.getSystemInfoSync()
+  const wxPerf = wx.getPerformance()
+  const initTime = wxPerf.now()
+
+  const clientPerfAdapter = Object.assign({}, wxPerf, {
+    now: function() {
+      return (wxPerf.now() - initTime) / 1000
+    }
+  })
+
+  performance = platform === 'devtools' ? wxPerf : clientPerfAdapter
+}
+
+export default performance


### PR DESCRIPTION
window.performance.now 在真机上返回值的单位不正确，暂时通过 adapter 来适配。